### PR TITLE
Avoid installing the test libs, fix cpp tests

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -48,32 +48,46 @@ ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")
-set(PROJECT_TARGETS ${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  set(TEST_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/test_libs")
+
   add_library(rosidl_typesupport_c__test_type_support1
     test/test_type_support.c)
   target_include_directories(rosidl_typesupport_c__test_type_support1 PRIVATE include)
-  ament_export_libraries(rosidl_typesupport_c__test_type_support1)
+  add_custom_command(TARGET rosidl_typesupport_c__test_type_support1 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    $<TARGET_FILE:rosidl_typesupport_c__test_type_support1>
+    ${TEST_LIB_DIR})
 
   # This same library is added a second type with a new name for additional tests
   add_library(rosidl_typesupport_c__test_type_support2
     test/test_type_support.c)
   target_include_directories(rosidl_typesupport_c__test_type_support2 PRIVATE include)
-  ament_export_libraries(rosidl_typesupport_c__test_type_support2)
-  set(PROJECT_TARGETS ${PROJECT_TARGETS} rosidl_typesupport_c__test_type_support1 rosidl_typesupport_c__test_type_support2)
+  add_custom_command(TARGET rosidl_typesupport_c__test_type_support2 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    $<TARGET_FILE:rosidl_typesupport_c__test_type_support2>
+    ${TEST_LIB_DIR})
 
-  ament_add_gtest(test_message_type_support test/test_message_type_support_dispatch.cpp)
+  ament_add_gtest(test_message_type_support test/test_message_type_support_dispatch.cpp
+    APPEND_ENV
+    "DYLD_LIBRARY_PATH=${TEST_LIB_DIR}"
+    "LD_LIBRARY_PATH=${TEST_LIB_DIR}"
+    "PATH=${TEST_LIB_DIR}")
   if(TARGET test_message_type_support)
     target_link_libraries(test_message_type_support
       ${PROJECT_NAME}
     )
   endif()
 
-  ament_add_gtest(test_service_type_support test/test_service_type_support_dispatch.cpp)
+  ament_add_gtest(test_service_type_support test/test_service_type_support_dispatch.cpp
+    APPEND_ENV
+    "DYLD_LIBRARY_PATH=${TEST_LIB_DIR}"
+    "LD_LIBRARY_PATH=${TEST_LIB_DIR}"
+    "PATH=${TEST_LIB_DIR}")
   if(TARGET test_service_type_support)
     target_link_libraries(test_service_type_support
       ${PROJECT_NAME}
@@ -81,10 +95,9 @@ if(BUILD_TESTING)
   endif()
 
   # Test type_support_dispatch throws runtime error when trying to load this "library"
-  set(INVALID_LIBRARY_FILE "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rosidl_typesupport_c__test_type_support3${CMAKE_SHARED_LIBRARY_SUFFIX}")
   file(GENERATE
     OUTPUT
-    ${INVALID_LIBRARY_FILE}
+    "${TEST_LIB_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rosidl_typesupport_c__test_type_support3${CMAKE_SHARED_LIBRARY_SUFFIX}"
     CONTENT "I'm not a shared library, why would you treat me like one?")
 endif()
 
@@ -111,18 +124,8 @@ install(
   DESTINATION include
 )
 install(
-  TARGETS ${PROJECT_TARGETS} EXPORT ${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
-
-if(BUILD_TESTING)
-  if(WIN32)
-  install(FILES ${INVALID_LIBRARY_FILE}
-          DESTINATION bin)
-  else()
-  install(FILES ${INVALID_LIBRARY_FILE}
-          DESTINATION lib)
-  endif()
-endif()

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -46,32 +46,46 @@ ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")
-set(PROJECT_TARGETS ${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  set(TEST_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/test_libs")
+
   add_library(rosidl_typesupport_cpp__test_type_support1
     test/test_type_support.cpp)
   target_include_directories(rosidl_typesupport_cpp__test_type_support1 PRIVATE include)
-  ament_export_libraries(rosidl_typesupport_cpp__test_type_support1)
+  add_custom_command(TARGET rosidl_typesupport_cpp__test_type_support1 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    $<TARGET_FILE:rosidl_typesupport_cpp__test_type_support1>
+    ${TEST_LIB_DIR})
 
   # This same library is added a second type with a new name for additional tests
   add_library(rosidl_typesupport_cpp__test_type_support2
     test/test_type_support.cpp)
   target_include_directories(rosidl_typesupport_cpp__test_type_support2 PRIVATE include)
-  ament_export_libraries(rosidl_typesupport_cpp__test_type_support2)
-  set(PROJECT_TARGETS ${PROJECT_TARGETS} rosidl_typesupport_cpp__test_type_support1 rosidl_typesupport_cpp__test_type_support2)
+  add_custom_command(TARGET rosidl_typesupport_cpp__test_type_support2 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    $<TARGET_FILE:rosidl_typesupport_cpp__test_type_support2>
+    ${TEST_LIB_DIR})
 
-  ament_add_gtest(test_message_type_support test/test_message_type_support_dispatch.cpp)
+  ament_add_gtest(test_message_type_support test/test_message_type_support_dispatch.cpp
+    APPEND_ENV
+    "DYLD_LIBRARY_PATH=${TEST_LIB_DIR}"
+    "LD_LIBRARY_PATH=${TEST_LIB_DIR}"
+    "PATH=${TEST_LIB_DIR}")
   if(TARGET test_message_type_support)
     target_link_libraries(test_message_type_support
       ${PROJECT_NAME}
     )
   endif()
 
-  ament_add_gtest(test_service_type_support test/test_service_type_support_dispatch.cpp)
+  ament_add_gtest(test_service_type_support test/test_service_type_support_dispatch.cpp
+    APPEND_ENV
+    "DYLD_LIBRARY_PATH=${TEST_LIB_DIR}"
+    "LD_LIBRARY_PATH=${TEST_LIB_DIR}"
+    "PATH=${TEST_LIB_DIR}")
   if(TARGET test_service_type_support)
     target_link_libraries(test_service_type_support
       ${PROJECT_NAME}
@@ -79,10 +93,9 @@ if(BUILD_TESTING)
   endif()
 
   # Test type_support_dispatch throws runtime error when trying to load this "library"
-  set(INVALID_LIBRARY_FILE "${CMAKE_CURRENT_BINARY_DIR}/librosidl_typesupport_cpp__test_type_support3${CMAKE_SHARED_LIBRARY_SUFFIX}")
   file(GENERATE
     OUTPUT
-    ${INVALID_LIBRARY_FILE}
+    "${TEST_LIB_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rosidl_typesupport_cpp__test_type_support3${CMAKE_SHARED_LIBRARY_SUFFIX}"
     CONTENT "I'm not a shared library, why would you treat me like one?")
 endif()
 
@@ -109,13 +122,8 @@ install(
   DESTINATION include
 )
 install(
-  TARGETS ${PROJECT_TARGETS} EXPORT ${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
-
-if(BUILD_TESTING)
-install(FILES ${INVALID_LIBRARY_FILE}
-        DESTINATION lib)
-endif()

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -19,7 +19,7 @@
 #include "rosidl_typesupport_cpp/type_support_map.h"
 
 constexpr size_t map_size = 4u;
-constexpr const char package_name[] = "rosidl_typesupport_c";
+constexpr const char package_name[] = "rosidl_typesupport_cpp";
 constexpr const char * identifiers[map_size] = {
   "test_type_support1", "test_type_support2", "test_type_support3", "test_type_support4"
 };
@@ -75,7 +75,7 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
       &type_support,
       "identifier"), &type_support);
 
-  // Identifier is not the same and isn't the rosidl_typesupport_c__typesupport_identifier
+  // Identifier is not the same and isn't the rosidl_typesupport_cpp__typesupport_identifier
   EXPECT_EQ(
     rosidl_typesupport_cpp::get_message_typesupport_handle_function(
       &type_support,

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -19,7 +19,7 @@
 #include "rosidl_typesupport_cpp/type_support_map.h"
 
 constexpr size_t map_size = 4u;
-constexpr const char package_name[] = "rosidl_typesupport_c";
+constexpr const char package_name[] = "rosidl_typesupport_cpp";
 constexpr const char * identifiers[map_size] = {
   "test_type_support1", "test_type_support2", "test_type_support3", "test_type_support4"
 };
@@ -75,7 +75,7 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
       &type_support,
       "identifier"), &type_support);
 
-  // Identifier is not the same and isn't the rosidl_typesupport_c__typesupport_identifier
+  // Identifier is not the same and isn't the rosidl_typesupport_cpp__typesupport_identifier
   EXPECT_EQ(
     rosidl_typesupport_cpp::get_service_typesupport_handle_function(
       &type_support,

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -16,6 +16,11 @@
 
 #include "rosidl_typesupport_cpp/visibility_control.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 // If ROSIDL_TYPESUPPORT_CPP_PUBLIC is used, it selects dllimport instead of dllexport, but the
 // function still needs to be defined separately. Windows has gotten picky with its compiler
 // warnings recently.
@@ -26,3 +31,7 @@ void test_type_support();
 #endif
 
 void test_type_support() {}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
I had some thoughts that would have been too difficult to express in ros2/rosidl_typesupport#63.

A few things here:
1. The `rosidl_typesupport_cpp` tests were targeting the stuff installed by `rosidl_typesupport_c`.
2. The `rosidl_typesupport_cpp` test library needed some extern markers to keep the c++ compiler from mangling the symbol name.
3. The `rosidl_typesupport_cpp` invalid library filename needed the prefix dropped on Windows.
4. I really didn't like the idea of installing test collateral and shipping it in the product - especially the "invalid" library. I updated the CMake logic with a post-build hook to copy the libraries to a staging location in the build directory, then used a few environment variables to tell Linux/OSX/Windows to search for the libraries there. Now installation isn't necessary, and we don't ship unnecessary test collateral.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10821)](http://ci.ros2.org/job/ci_linux/10821/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6198)](http://ci.ros2.org/job/ci_linux-aarch64/6198/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8811)](http://ci.ros2.org/job/ci_osx/8811/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10707)](http://ci.ros2.org/job/ci_windows/10707/)